### PR TITLE
Add find_entities helper method, for easy conversion between name and ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If any operation fails, `Flapjack::Diner.last_error` will contain an error messa
 
 * [create_entities](#create_entities)
 * [entities](#entities)
-* [find_entities](#find_entities)
+* [entities_matching](#entities_matching)
 * [update_entities](#update_entities)
 
 * [create_scheduled_maintenances_entities](#create_scheduled_maintenances_entities)
@@ -446,13 +446,13 @@ some_entities = Flapjack::Diner.entities(ID1, ID2, ...)
 all_entities = Flapjack::Diner.entities
 ```
 
-<a name="find_entities">&nbsp;</a>
-### find_entities
+<a name="entities_matching">&nbsp;</a>
+### entities_matching
 
-Returns an array of entities beginning with a particular string
+Returns an array of entities matching a given regular expression
 
 ```ruby
-entities = Flapjack::Diner.find_entities(NAME)
+entities = Flapjack::Diner.entities_matching(/^db-app-01/)
 ```
 
 <a name="update_entities">&nbsp;</a>

--- a/lib/flapjack-diner.rb
+++ b/lib/flapjack-diner.rb
@@ -240,8 +240,9 @@ module Flapjack
         extract_get('checks', perform_get('/checks', ids))
       end
 
-      def find_entities(name)
-        entities = self.entities.select {|a| a[:name].start_with?(name) }
+      def entities_matching(name_re)
+        raise "Must be a regexp: #{name_re.inspect}" unless name_re.is_a?(Regexp)
+        self.entities.select {|e| name_re === e[:name] }
       end
 
       def update_entities(*args)


### PR DESCRIPTION
This is the function that I'm having to define in each piece of code that uses flapjack diner 1.0.

@ali-graham What are your thoughts on including this into diner before 2.0 comes out?  
