### PR TITLE
Make Sure Hash Keys are Symbolized

### DIFF
--- a/lib/flapjack-diner/tools.rb
+++ b/lib/flapjack-diner/tools.rb
@@ -159,7 +159,7 @@ module Flapjack
             raise "Array arguments may only contain data Hashes" unless arg.all? {|a| a.is_a?(Hash)}
             data += arg
           when Hash
-            params.update(arg)
+            params.update(symbolize(arg))
           when String, Integer
             ids << arg.to_s
           else


### PR DESCRIPTION
The internal implementation is relying on hashes with symbols as keys (e.g. [this part](https://github.com/flapjack/flapjack-diner/blob/master/lib/flapjack-diner/resources/notification_rules.rb#L41-L52)). Hence, external hash input should be symbolized by default.

Wasn't sure where to put tests for this since tools isn't tested directly. Suggestions?
