### PR TITLE
Add the corresponding endpoint to entities_matching for checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,15 @@ some_checks = Flapjack::Diner.checks(ID1, ID2, ...)
 all_checks = Flapjack::Diner.checks
 ```
 
+<a name="checks_matching">&nbsp;</a>
+### checks_matching
+
+Returns an array of checks matching a given regular expression
+
+```ruby
+entities = Flapjack::Diner.checks_matching(/^PING/)
+```
+
 <a name="update_checks">&nbsp;</a>
 ### update_checks
 

--- a/lib/flapjack-diner/resources/checks.rb
+++ b/lib/flapjack-diner/resources/checks.rb
@@ -23,6 +23,12 @@ module Flapjack
           perform_get('checks', '/checks', ids)
         end
 
+        def checks_matching(name_re)
+          raise "Must be a regexp: #{name_re.inspect}" unless
+            name_re.is_a?(Regexp)
+          checks.reject {|e| name_re.match(e[:name]).nil? }
+        end
+
         def update_checks(*args)
           ids, params = unwrap_ids(*args), unwrap_params(*args)
           raise "'update_checks' requires at least one check id " \


### PR DESCRIPTION
My use case for this is where we want to set downtime on a given check over a number of entities, without knowing in advance what those entities are.

For example, one of our appliances had updates recently which triggered alerts across a number of entities, all on the particular check name.  We'd like to be able to acknowledge / downtime these easily.