### PR TITLE
pagerduty_credentials to use token instead of username/password

### DIFF
--- a/lib/flapjack-diner/resources/pagerduty_credentials.rb
+++ b/lib/flapjack-diner/resources/pagerduty_credentials.rb
@@ -30,7 +30,7 @@ module Flapjack
                 ' pagerduty_credentials id parameter' if ids.nil? || ids.empty?
           validate_params(params) do
             validate :query => [:service_key, :subdomain,
-                                :username, :password], :as => :string
+                                :token], :as => :string
           end
           perform_patch("/pagerduty_credentials/#{escaped_ids(ids)}",
                         nil, update_pagerduty_credentials_ops(params))
@@ -46,8 +46,7 @@ module Flapjack
 
         def update_pagerduty_credentials_ops(params)
           ops = params.each_with_object([]) do |(k, v), memo|
-            next unless [:service_key, :subdomain,
-                         :username, :password].include?(k)
+            next unless [:service_key, :subdomain, :token].include?(k)
             memo << patch_replace('pagerduty_credentials', k, v)
           end
           raise "'update_pagerduty_credentials' did not find any valid " \

--- a/spec/pacts/flapjack-diner-flapjack.json
+++ b/spec/pacts/flapjack-diner-flapjack.json
@@ -7,1756 +7,1972 @@
   },
   "interactions": [
     {
-      "description": "a time limited GET request for a outage report on one entity",
+      "description": "a POST request with one test notification",
       "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time-limited GET request for a downtime report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A27%2B10%3A30&end_time=2014-12-02T22%3A31%3A27%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time-limited GET request for a scheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/status_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on all entities",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time-limited GET request for a outage report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a downtime report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a outage report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a scheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A28%2B10%3A30&end_time=2014-12-02T22%3A31%3A28%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a status report on all checks",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/status_report/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "status_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a scheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/scheduled_maintenance_report/entities/1234"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "scheduled_maintenance_reports": [
-            {
-              "scheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a outage report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/outage_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "outage_reports": [
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "outages": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a unscheduled_maintenance report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            },
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time-limited GET request for a unscheduled_maintenance report on two checks",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a unscheduled_maintenance report on two entities",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "get",
-        "path": "/unscheduled_maintenance_report/entities/1234,5678"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "unscheduled_maintenance_reports": [
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "1234"
-                ],
-                "check": [
-                  "www.example.com:SSH"
-                ]
-              }
-            },
-            {
-              "unscheduled_maintenances": [
-
-              ],
-              "links": {
-                "entity": [
-                  "5678"
-                ],
-                "check": [
-                  "www2.example.com:PING"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a time limited GET request for a downtime report on one entity",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "get",
-        "path": "/downtime_report/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A29%2B10%3A30&end_time=2014-12-02T22%3A31%3A29%2B10%3A30"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "downtime_reports": [
-            {
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one medium",
-      "provider_state": "a contact with id 'abc' exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/media",
+        "path": "/test_notifications/checks/www.example.com:SSH",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "media": [
+          "test_notifications": [
             {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
+              "summary": "testing"
             }
           ]
         }
       },
       "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc_sms"
-        ]
+        "status": 204,
+        "body": ""
       }
     },
     {
-      "description": "a POST request with two media",
-      "provider_state": "a contact with id 'abc' exists",
+      "description": "a POST request with one test notification",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/media",
+        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "media": [
+          "test_notifications": [
             {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
-            },
-            {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3
+              "summary": "testing"
             }
           ]
         }
       },
       "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc_sms",
-          "abc_email"
-        ]
+        "status": 204,
+        "body": ""
       }
     },
     {
-      "description": "a POST request with one medium",
+      "description": "a POST request with two test notifications",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two test notifications",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            },
+            {
+              "summary": "more tests"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one test notification",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/test_notifications/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "test_notifications": [
+            {
+              "summary": "testing"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts/abc"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contacts 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts/abc"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all contacts",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "contacts": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all contacts",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "get",
+        "path": "/contacts"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two contacts",
+      "provider_state": "contacts with ids 'abc' and '872' exist",
+      "request": {
+        "method": "delete",
+        "path": "/contacts/abc,872",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a single contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "delete",
+        "path": "/contacts/abc",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contacts 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "delete",
+        "path": "/contacts/abc",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for a single contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "patch",
+        "path": "/contacts/abc",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/contacts/0/timezone",
+            "value": "UTC"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for two contacts",
+      "provider_state": "contacts with ids 'abc' and '872' exist",
+      "request": {
+        "method": "patch",
+        "path": "/contacts/abc,872",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/contacts/0/timezone",
+            "value": "UTC"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change links for two contacts",
+      "provider_state": "contacts with ids 'abc' and '872' exist",
+      "request": {
+        "method": "patch",
+        "path": "/contacts/abc,872",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "add",
+            "path": "/contacts/0/links/entities/-",
+            "value": "1234"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH requestto change a link for a single contact",
+      "provider_state": "a contact with id '872' exists",
+      "request": {
+        "method": "patch",
+        "path": "/contacts/872",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "add",
+            "path": "/contacts/0/links/entities/-",
+            "value": "1234"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for a single contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "patch",
+        "path": "/contacts/323",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/contacts/0/timezone",
+            "value": "UTC"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contacts '323'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with two contacts",
       "provider_state": "no contact exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/media",
+        "path": "/contacts",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "media": [
+          "contacts": [
             {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            },
+            {
+              "id": "def",
+              "first_name": "Joan",
+              "last_name": "Smith",
+              "email": "joans@example.com"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "abc",
+          "def"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one contact",
+      "provider_state": "a contact with id 'abc' exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 409,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "Contacts already exist with the following IDs: abc"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one contact",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "contacts": [
+            {
+              "id": "abc",
+              "first_name": "Jim",
+              "last_name": "Smith",
+              "email": "jims@example.com",
+              "timezone": "UTC"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "abc"
+        ]
+      }
+    },
+    {
+      "description": "a GET request for check 'www.example.com:SSH'",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity checks: 'www.example.com:SSH'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for check 'www.example.com:SSH'",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "checks": [
+            {
+              "id": "www.example.com:SSH",
+              "name": "SSH",
+              "entity_name": "www.example.com",
+              "links": {
+                "entities": [
+                  "1234"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "checks": [
+            {
+              "id": "www.example.com:SSH",
+              "name": "SSH",
+              "entity_name": "www.example.com",
+              "links": {
+                "entities": [
+                  "1234"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all checks",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "checks": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for a single check",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/checks/0/enabled",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "patch",
+        "path": "/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/checks/0/enabled",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two checks",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/checks",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "checks": [
+            {
+              "name": "SSH",
+              "entity_id": "1234"
+            },
+            {
+              "name": "PING",
+              "entity_id": "5678"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "www.example.com:SSH",
+          "www2.example.com:PING"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one check",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/checks",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "checks": [
+            {
+              "name": "SSH",
+              "entity_id": "1234"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "www.example.com:SSH"
+        ]
+      }
+    },
+    {
+      "description": "a GET request for a single entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/entities/1234"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entities: '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a single entity",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "get",
+        "path": "/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "www.example.com",
+              "id": "1234"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all entities",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "get",
+        "path": "/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "entities": [
+
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all entities",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "get",
+        "path": "/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "www.example.com",
+              "id": "1234"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for a single entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/entities/0/name",
+            "value": "example3.com"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for a single entity",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "patch",
+        "path": "/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/entities/0/name",
+            "value": "example3.com"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two entities",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/entities",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "example.org",
+              "id": "57_example"
+            },
+            {
+              "name": "example2.org",
+              "id": "58"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "57_example",
+          "58"
+        ]
+      }
+    },
+    {
+      "description": "a POST request with one entity",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/entities",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "entities": [
+            {
+              "name": "example.org",
+              "id": "57_example"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "57_example"
+        ]
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:36-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:36-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:36-07:00",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-04-08T17:50:36-07:00",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:36-07:00",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-04-08T17:50:36-07:00",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "no check exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:36-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity 'www.example.com'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for an unscheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "patch",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/unscheduled_maintenances/0/end_time",
+            "value": "2015-04-08T15:50:36-07:00"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234,5678",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for a scheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "delete",
+        "path": "/scheduled_maintenances/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A36-07%3A00"
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two unscheduled maintenance periods",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one unscheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/unscheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "unscheduled_maintenances": [
+            {
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:37-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:37-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234,5678",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:37-07:00",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-04-08T17:50:37-07:00",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with two scheduled maintenance periods",
+      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:37-07:00",
+              "duration": 3600,
+              "summary": "working"
+            },
+            {
+              "start_time": "2015-04-08T17:50:37-07:00",
+              "duration": 3600,
+              "summary": "more work"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one scheduled maintenance period",
+      "provider_state": "no entity exists",
+      "request": {
+        "method": "post",
+        "path": "/scheduled_maintenances/entities/1234",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "scheduled_maintenances": [
+            {
+              "start_time": "2015-04-08T15:50:37-07:00",
+              "duration": 3600,
+              "summary": "working"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 404,
+        "body": {
+          "errors": [
+            "could not find entity '1234'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for one set of pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "get",
+        "path": "/pagerduty_credentials/abc"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "token": "ghi"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for one set of pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/pagerduty_credentials/abc"
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for two sets of pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
+      "request": {
+        "method": "get",
+        "path": "/pagerduty_credentials/abc,872"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "token": "ghi"
+            },
+            {
+              "service_key": "mno",
+              "subdomain": "pqr",
+              "token": "stu"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "get",
+        "path": "/pagerduty_credentials"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "token": "ghi"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two sets of pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc,872",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one set of pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for one set of pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "delete",
+        "path": "/pagerduty_credentials/abc",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc,872",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request for pagerduty credentials",
+      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "request": {
+        "method": "patch",
+        "path": "/pagerduty_credentials/abc",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/pagerduty_credentials/0/token",
+            "value": "token123"
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a POST request with one set of pagerduty credentials",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "post",
+        "path": "/contacts/abc/pagerduty_credentials",
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "token": "ghi"
             }
           ]
         }
@@ -1774,282 +1990,65 @@
       }
     },
     {
-      "description": "a GET request for all media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "get",
-        "path": "/media"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            },
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "get",
-        "path": "/media/abc_sms"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for email and sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "get",
-        "path": "/media/abc_email,abc_sms"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "media": [
-            {
-              "type": "email",
-              "address": "ablated@example.org",
-              "interval": 180,
-              "rollup_threshold": 3,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            },
-            {
-              "type": "sms",
-              "address": "0123456789",
-              "interval": 300,
-              "rollup_threshold": 5,
-              "links": {
-                "contacts": [
-                  "abc"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for sms media",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/media/abc_sms"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for email media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "patch",
-        "path": "/media/abc_email",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          },
-          {
-            "op": "replace",
-            "path": "/media/0/rollup_threshold",
-            "value": 3
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for email and sms media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "patch",
-        "path": "/media/abc_email,abc_sms",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          },
-          {
-            "op": "replace",
-            "path": "/media/0/rollup_threshold",
-            "value": 3
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for email media",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "patch",
-        "path": "/media/abc_email",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/media/0/interval",
-            "value": 50
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for one medium",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two media",
-      "provider_state": "a contact with id 'abc' has email and sms media",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email,abc_sms",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for one medium",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "delete",
-        "path": "/media/abc_email",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one notification rule",
+      "description": "a POST request with one set of pagerduty credentials",
       "provider_state": "a contact with id 'abc' exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/notification_rules",
+        "path": "/contacts/abc/pagerduty_credentials",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
+          "pagerduty_credentials": [
+            {
+              "service_key": "abc",
+              "subdomain": "def",
+              "token": "ghi"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": [
+          "abc"
+        ]
+      }
+    },
+    {
+      "description": "a GET request for a single notification rule",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "request": {
+        "method": "get",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
           "notification_rules": [
             {
-              "entity_tags": [
-                "database",
-                "physical"
+              "id": "05983623-fcef-42da-af44-ed6990b500fa",
+              "tags": [
+
+              ],
+              "regex_tags": [
+
               ],
               "entities": [
-                "foo-app-01.example.com"
+
               ],
-              "time_restrictions": null,
+              "regex_entities": [
+
+              ],
+              "time_restrictions": [
+
+              ],
               "warning_media": [
                 "email"
               ],
@@ -2062,21 +2061,261 @@
             }
           ]
         }
+      }
+    },
+    {
+      "description": "a GET request for a single notification rule",
+      "provider_state": "no notification rule exists",
+      "request": {
+        "method": "get",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
       },
       "response": {
-        "status": 201,
+        "status": 404,
         "headers": {
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
+        "body": {
+          "errors": [
+            "could not find notification rules '05983623-fcef-42da-af44-ed6990b500fa'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for two notification rules",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
+      "request": {
+        "method": "get",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "notification_rules": [
+            {
+              "id": "05983623-fcef-42da-af44-ed6990b500fa",
+              "tags": [
+
+              ],
+              "regex_tags": [
+
+              ],
+              "entities": [
+
+              ],
+              "regex_entities": [
+
+              ],
+              "time_restrictions": [
+
+              ],
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": false,
+              "critical_blackhole": false
+            },
+            {
+              "id": "20f182fc-6e32-4794-9007-97366d162c51",
+              "tags": [
+                "physical"
+              ],
+              "regex_tags": [
+
+              ],
+              "entities": [
+                "example.com"
+              ],
+              "regex_entities": [
+
+              ],
+              "time_restrictions": [
+
+              ],
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": true,
+              "critical_blackhole": true
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all notification rules",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "request": {
+        "method": "get",
+        "path": "/notification_rules"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "notification_rules": [
+            {
+              "id": "05983623-fcef-42da-af44-ed6990b500fa",
+              "tags": [
+
+              ],
+              "regex_tags": [
+
+              ],
+              "entities": [
+
+              ],
+              "regex_entities": [
+
+              ],
+              "time_restrictions": [
+
+              ],
+              "warning_media": [
+                "email"
+              ],
+              "critical_media": [
+                "sms",
+                "email"
+              ],
+              "warning_blackhole": false,
+              "critical_blackhole": false
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two notification rules",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
+      "request": {
+        "method": "delete",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for a single notification rule",
+      "provider_state": "no notification rule exists",
+      "request": {
+        "method": "delete",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find notification rule '05983623-fcef-42da-af44-ed6990b500fa'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for a single notification rule",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "request": {
+        "method": "delete",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for two notification rules",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
+      "request": {
+        "method": "patch",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
         "body": [
           {
-            "json_class": "Pact::Term",
-            "data": {
-              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
-              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
-            }
+            "op": "replace",
+            "path": "/notification_rules/0/warning_blackhole",
+            "value": false
           }
         ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for a single notification rule",
+      "provider_state": "no notification rule exists",
+      "request": {
+        "method": "patch",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/notification_rules/0/warning_blackhole",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find notification rule '05983623-fcef-42da-af44-ed6990b500fa'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a PATCH request to change properties for a single notification rule",
+      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "request": {
+        "method": "patch",
+        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
+        "headers": {
+          "Content-Type": "application/json-patch+json"
+        },
+        "body": [
+          {
+            "op": "replace",
+            "path": "/notification_rules/0/warning_blackhole",
+            "value": false
+          }
+        ]
+      },
+      "response": {
+        "status": 204,
+        "body": ""
       }
     },
     {
@@ -2197,153 +2436,25 @@
       }
     },
     {
-      "description": "a GET request for all notification rules",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
+      "description": "a POST request with one notification rule",
+      "provider_state": "a contact with id 'abc' exists",
       "request": {
-        "method": "get",
-        "path": "/notification_rules"
-      },
-      "response": {
-        "status": 200,
+        "method": "post",
+        "path": "/contacts/abc/notification_rules",
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json"
         },
         "body": {
           "notification_rules": [
             {
-              "id": "05983623-fcef-42da-af44-ed6990b500fa",
-              "tags": [
-
-              ],
-              "regex_tags": [
-
-              ],
-              "entities": [
-
-              ],
-              "regex_entities": [
-
-              ],
-              "time_restrictions": [
-
-              ],
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single notification rule",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
-      "request": {
-        "method": "get",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "notification_rules": [
-            {
-              "id": "05983623-fcef-42da-af44-ed6990b500fa",
-              "tags": [
-
-              ],
-              "regex_tags": [
-
-              ],
-              "entities": [
-
-              ],
-              "regex_entities": [
-
-              ],
-              "time_restrictions": [
-
-              ],
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for two notification rules",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
-      "request": {
-        "method": "get",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "notification_rules": [
-            {
-              "id": "05983623-fcef-42da-af44-ed6990b500fa",
-              "tags": [
-
-              ],
-              "regex_tags": [
-
-              ],
-              "entities": [
-
-              ],
-              "regex_entities": [
-
-              ],
-              "time_restrictions": [
-
-              ],
-              "warning_media": [
-                "email"
-              ],
-              "critical_media": [
-                "sms",
-                "email"
-              ],
-              "warning_blackhole": false,
-              "critical_blackhole": false
-            },
-            {
-              "id": "20f182fc-6e32-4794-9007-97366d162c51",
-              "tags": [
+              "entity_tags": [
+                "database",
                 "physical"
               ],
-              "regex_tags": [
-
-              ],
               "entities": [
-                "example.com"
+                "foo-app-01.example.com"
               ],
-              "regex_entities": [
-
-              ],
-              "time_restrictions": [
-
-              ],
+              "time_restrictions": null,
               "warning_media": [
                 "email"
               ],
@@ -2351,498 +2462,35 @@
                 "sms",
                 "email"
               ],
-              "warning_blackhole": true,
-              "critical_blackhole": true
+              "warning_blackhole": false,
+              "critical_blackhole": false
             }
           ]
         }
-      }
-    },
-    {
-      "description": "a GET request for a single notification rule",
-      "provider_state": "no notification rule exists",
-      "request": {
-        "method": "get",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa"
       },
       "response": {
-        "status": 404,
+        "status": 201,
         "headers": {
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
-        "body": {
-          "errors": [
-            "could not find notification rules '05983623-fcef-42da-af44-ed6990b500fa'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request to change properties for a single notification rule",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
-      "request": {
-        "method": "patch",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
         "body": [
           {
-            "op": "replace",
-            "path": "/notification_rules/0/warning_blackhole",
-            "value": false
+            "json_class": "Pact::Term",
+            "data": {
+              "generate": "05983623-fcef-42da-af44-ed6990b500fa",
+              "matcher": {"json_class":"Regexp","o":0,"s":"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"}
+            }
           }
         ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
       }
     },
     {
-      "description": "a PATCH request to change properties for two notification rules",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
-      "request": {
-        "method": "patch",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/notification_rules/0/warning_blackhole",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request to change properties for a single notification rule",
-      "provider_state": "no notification rule exists",
-      "request": {
-        "method": "patch",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/notification_rules/0/warning_blackhole",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find notification rule '05983623-fcef-42da-af44-ed6990b500fa'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for a single notification rule",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' exists",
-      "request": {
-        "method": "delete",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two notification rules",
-      "provider_state": "a contact 'abc' with generic notification rule '05983623-fcef-42da-af44-ed6990b500fa' and notification rule '20f182fc-6e32-4794-9007-97366d162c51' exists",
-      "request": {
-        "method": "delete",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa,20f182fc-6e32-4794-9007-97366d162c51",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a single notification rule",
-      "provider_state": "no notification rule exists",
-      "request": {
-        "method": "delete",
-        "path": "/notification_rules/05983623-fcef-42da-af44-ed6990b500fa",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find notification rule '05983623-fcef-42da-af44-ed6990b500fa'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two test notifications",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two test notifications",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one test notification",
+      "description": "a time limited GET request for a downtime report on two entities",
       "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two test notifications",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two test notifications",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/test_notifications/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "test_notifications": [
-            {
-              "summary": "testing"
-            },
-            {
-              "summary": "more tests"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one contact",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two contacts",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            },
-            {
-              "id": "def",
-              "first_name": "Joan",
-              "last_name": "Smith",
-              "email": "joans@example.com"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "abc",
-          "def"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with one contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "post",
-        "path": "/contacts",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 409,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "Contacts already exist with the following IDs: abc"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all contacts",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
         "method": "get",
-        "path": "/contacts"
+        "path": "/downtime_report/entities/1234,5678",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
       },
       "response": {
         "status": 200,
@@ -2850,330 +2498,21 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": {
-          "contacts": [
+          "downtime_reports": [
             {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all contacts",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "contacts": [
-
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts/abc"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "contacts": [
-            {
-              "id": "abc",
-              "first_name": "Jim",
-              "last_name": "Smith",
-              "email": "jims@example.com",
-              "timezone": "UTC"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for a single contact",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/contacts/abc"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contacts 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request to change properties for a single contact",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "patch",
-        "path": "/contacts/323",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/contacts/0/timezone",
-            "value": "UTC"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contacts '323'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request to change properties for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "patch",
-        "path": "/contacts/abc",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/contacts/0/timezone",
-            "value": "UTC"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request to change properties for two contacts",
-      "provider_state": "contacts with ids 'abc' and '872' exist",
-      "request": {
-        "method": "patch",
-        "path": "/contacts/abc,872",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/contacts/0/timezone",
-            "value": "UTC"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH requestto change a link for a single contact",
-      "provider_state": "a contact with id '872' exists",
-      "request": {
-        "method": "patch",
-        "path": "/contacts/872",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "add",
-            "path": "/contacts/0/links/entities/-",
-            "value": "1234"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request to change links for two contacts",
-      "provider_state": "contacts with ids 'abc' and '872' exist",
-      "request": {
-        "method": "patch",
-        "path": "/contacts/abc,872",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "add",
-            "path": "/contacts/0/links/entities/-",
-            "value": "1234"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a single contact",
-      "provider_state": "a contact with id 'abc' exists",
-      "request": {
-        "method": "delete",
-        "path": "/contacts/abc",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two contacts",
-      "provider_state": "contacts with ids 'abc' and '872' exist",
-      "request": {
-        "method": "delete",
-        "path": "/contacts/abc,872",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a single contact",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "delete",
-        "path": "/contacts/abc",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contacts 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one check",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/checks",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "checks": [
-            {
-              "name": "SSH",
-              "entity_id": "1234"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "www.example.com:SSH"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two checks",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/checks",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "checks": [
-            {
-              "name": "SSH",
-              "entity_id": "1234"
             },
             {
-              "name": "PING",
-              "entity_id": "5678"
             }
           ]
         }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "www.example.com:SSH",
-          "www2.example.com:PING"
-        ]
       }
     },
     {
-      "description": "a GET request for all checks",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/checks"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "checks": [
-
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all checks",
+      "description": "a GET request for a status report on all entities",
       "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/checks"
+        "path": "/status_report/entities"
       },
       "response": {
         "status": 200,
@@ -3181,14 +2520,37 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": {
-          "checks": [
+          "status_reports": [
             {
-              "id": "www.example.com:SSH",
-              "name": "SSH",
-              "entity_name": "www.example.com",
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
               "links": {
-                "entities": [
+                "entity": [
                   "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
                 ]
               }
             }
@@ -3197,11 +2559,11 @@
       }
     },
     {
-      "description": "a GET request for check 'www.example.com:SSH'",
+      "description": "a GET request for a outage report on all entities",
       "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/checks/www.example.com:SSH"
+        "path": "/outage_report/entities"
       },
       "response": {
         "status": 200,
@@ -3209,14 +2571,17 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": {
-          "checks": [
+          "outage_reports": [
             {
-              "id": "www.example.com:SSH",
-              "name": "SSH",
-              "entity_name": "www.example.com",
+              "outages": [
+
+              ],
               "links": {
-                "entities": [
+                "entity": [
                   "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
                 ]
               }
             }
@@ -3225,142 +2590,12 @@
       }
     },
     {
-      "description": "a GET request for check 'www.example.com:SSH'",
-      "provider_state": "no entity exists",
+      "description": "a time-limited GET request for a scheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
       "request": {
         "method": "get",
-        "path": "/checks/www.example.com:SSH"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entity checks: 'www.example.com:SSH'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for a single check",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "patch",
-        "path": "/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/checks/0/enabled",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for a single check",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "patch",
-        "path": "/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/checks/0/enabled",
-            "value": false
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one entity",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/entities",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "example.org",
-              "id": "57_example"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "57_example"
-        ]
-      }
-    },
-    {
-      "description": "a POST request with two entities",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/entities",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "entities": [
-            {
-              "name": "example.org",
-              "id": "57_example"
-            },
-            {
-              "name": "example2.org",
-              "id": "58"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 201,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": [
-          "57_example",
-          "58"
-        ]
-      }
-    },
-    {
-      "description": "a GET request for all entities",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "get",
-        "path": "/entities"
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
       },
       "response": {
         "status": 200,
@@ -3368,40 +2603,44 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": {
-          "entities": [
+          "scheduled_maintenance_reports": [
             {
-              "name": "www.example.com",
-              "id": "1234"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for all entities",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "get",
-        "path": "/entities"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "entities": [
+              "scheduled_maintenances": [
 
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
           ]
         }
       }
     },
     {
-      "description": "a GET request for a single entity",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "description": "a time limited GET request for a downtime report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/entities/1234"
+        "path": "/downtime_report/entities",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
       },
       "response": {
         "status": 200,
@@ -3409,21 +2648,1545 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": {
-          "entities": [
+          "downtime_reports": [
             {
-              "name": "www.example.com",
-              "id": "1234"
             }
           ]
         }
       }
     },
     {
-      "description": "a GET request for a single entity",
-      "provider_state": "no entity exists",
+      "description": "a GET request for a status report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
       "request": {
         "method": "get",
-        "path": "/entities/1234"
+        "path": "/status_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/status_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/status_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time-limited GET request for a unscheduled_maintenance report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks",
+        "query": "start_time=2015-04-08T15%3A50%3A37-07%3A00&end_time=2015-04-09T03%3A50%3A37-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a downtime report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on all checks",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time-limited GET request for a downtime report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/status_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234,5678",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/entities/1234",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a outage report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/entities/1234,5678",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a scheduled_maintenance report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a unscheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234,5678"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a scheduled_maintenance report on one entity",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/scheduled_maintenance_report/entities/1234"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "scheduled_maintenance_reports": [
+            {
+              "scheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a status report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/status_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "status_reports": [
+            {
+            },
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on all entities",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for a outage report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a downtime report on a single check",
+      "provider_state": "a check 'www.example.com:SSH' exists",
+      "request": {
+        "method": "get",
+        "path": "/downtime_report/checks/www.example.com:SSH",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "downtime_reports": [
+            {
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time-limited GET request for a outage report on two checks",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/outage_report/checks/www.example.com:SSH,www2.example.com:PING",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "outage_reports": [
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "outages": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a time limited GET request for a unscheduled_maintenance report on two entities",
+      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
+      "request": {
+        "method": "get",
+        "path": "/unscheduled_maintenance_report/entities/1234,5678",
+        "query": "start_time=2015-04-08T15%3A50%3A38-07%3A00&end_time=2015-04-09T03%3A50%3A38-07%3A00"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "unscheduled_maintenance_reports": [
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "1234"
+                ],
+                "check": [
+                  "www.example.com:SSH"
+                ]
+              }
+            },
+            {
+              "unscheduled_maintenances": [
+
+              ],
+              "links": {
+                "entity": [
+                  "5678"
+                ],
+                "check": [
+                  "www2.example.com:PING"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_sms"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for sms media",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_sms"
       },
       "response": {
         "status": 404,
@@ -3432,25 +4195,156 @@
         },
         "body": {
           "errors": [
-            "could not find entities: '1234'"
+            "could not find contact 'abc'"
           ]
         }
       }
     },
     {
-      "description": "a PATCH request for a single entity",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "description": "a GET request for email and sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media/abc_email,abc_sms"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            },
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a GET request for all media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "get",
+        "path": "/media"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "media": [
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            },
+            {
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5,
+              "links": {
+                "contacts": [
+                  "abc"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for two media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email,abc_sms",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a DELETE request for one medium",
+      "provider_state": "no contact exists",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email",
+        "body": null
+      },
+      "response": {
+        "status": 404,
+        "headers": {
+          "Content-Type": "application/vnd.api+json; charset=utf-8"
+        },
+        "body": {
+          "errors": [
+            "could not find contact 'abc'"
+          ]
+        }
+      }
+    },
+    {
+      "description": "a DELETE request for one medium",
+      "provider_state": "a contact with id 'abc' has email and sms media",
+      "request": {
+        "method": "delete",
+        "path": "/media/abc_email",
+        "body": null
+      },
+      "response": {
+        "status": 204,
+        "body": ""
+      }
+    },
+    {
+      "description": "a PATCH request for email and sms media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
       "request": {
         "method": "patch",
-        "path": "/entities/1234",
+        "path": "/media/abc_email,abc_sms",
         "headers": {
           "Content-Type": "application/json-patch+json"
         },
         "body": [
           {
             "op": "replace",
-            "path": "/entities/0/name",
-            "value": "example3.com"
+            "path": "/media/0/interval",
+            "value": 50
+          },
+          {
+            "op": "replace",
+            "path": "/media/0/rollup_threshold",
+            "value": 3
           }
         ]
       },
@@ -3460,19 +4354,19 @@
       }
     },
     {
-      "description": "a PATCH request for a single entity",
-      "provider_state": "no entity exists",
+      "description": "a PATCH request for email media",
+      "provider_state": "no contact exists",
       "request": {
         "method": "patch",
-        "path": "/entities/1234",
+        "path": "/media/abc_email",
         "headers": {
           "Content-Type": "application/json-patch+json"
         },
         "body": [
           {
             "op": "replace",
-            "path": "/entities/0/name",
-            "value": "example3.com"
+            "path": "/media/0/interval",
+            "value": 50
           }
         ]
       },
@@ -3483,286 +4377,30 @@
         },
         "body": {
           "errors": [
-            "could not find entity '1234'"
+            "could not find contact 'abc'"
           ]
         }
       }
     },
     {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:31+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:31+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:31+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
+      "description": "a PATCH request for email media",
+      "provider_state": "a contact with id 'abc' has email and sms media",
       "request": {
         "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234",
+        "path": "/media/abc_email",
         "headers": {
           "Content-Type": "application/json-patch+json"
         },
         "body": [
           {
             "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:31+10:30"
+            "path": "/media/0/interval",
+            "value": 50
+          },
+          {
+            "op": "replace",
+            "path": "/media/0/rollup_threshold",
+            "value": 3
           }
         ]
       },
@@ -3772,486 +4410,27 @@
       }
     },
     {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234,5678",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:31+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/entities/1234",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "an entity 'www.example.com' with id '1234' exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "entities 'www.example.com', id '1234' and 'www2.example.com', id '5678' exist",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234,5678",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "no entity exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/entities/1234",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity '1234'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one scheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:32+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two scheduled maintenance periods",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "scheduled_maintenances": [
-            {
-              "start_time": "2014-12-02T10:31:32+10:30",
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "start_time": "2014-12-02T12:31:32+10:30",
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with one unscheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a POST request with two unscheduled maintenance periods",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "post",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/vnd.api+json"
-        },
-        "body": {
-          "unscheduled_maintenances": [
-            {
-              "duration": 3600,
-              "summary": "working"
-            },
-            {
-              "duration": 3600,
-              "summary": "more work"
-            }
-          ]
-        }
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for an unscheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "patch",
-        "path": "/unscheduled_maintenances/checks/www.example.com:SSH",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/unscheduled_maintenances/0/end_time",
-            "value": "2014-12-02T10:31:32+10:30"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "a check 'www.example.com:SSH' exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "checks 'www.example.com:SSH' and 'www2.example.com:PING' exist",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH,www2.example.com:PING",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for a scheduled maintenance period",
-      "provider_state": "no check exists",
-      "request": {
-        "method": "delete",
-        "path": "/scheduled_maintenances/checks/www.example.com:SSH",
-        "query": "start_time=2014-12-02T10%3A31%3A32%2B10%3A30"
-      },
-      "response": {
-        "status": 404,
-        "body": {
-          "errors": [
-            "could not find entity 'www.example.com'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a POST request with one set of pagerduty credentials",
+      "description": "a POST request with two media",
       "provider_state": "a contact with id 'abc' exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/pagerduty_credentials",
+        "path": "/contacts/abc/media",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "pagerduty_credentials": [
+          "media": [
             {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
+            },
+            {
+              "type": "email",
+              "address": "ablated@example.org",
+              "interval": 180,
+              "rollup_threshold": 3
             }
           ]
         }
@@ -4262,26 +4441,27 @@
           "Content-Type": "application/vnd.api+json; charset=utf-8"
         },
         "body": [
-          "abc"
+          "abc_sms",
+          "abc_email"
         ]
       }
     },
     {
-      "description": "a POST request with one set of pagerduty credentials",
+      "description": "a POST request with one medium",
       "provider_state": "no contact exists",
       "request": {
         "method": "post",
-        "path": "/contacts/abc/pagerduty_credentials",
+        "path": "/contacts/abc/media",
         "headers": {
           "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "pagerduty_credentials": [
+          "media": [
             {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
             }
           ]
         }
@@ -4299,219 +4479,33 @@
       }
     },
     {
-      "description": "a GET request for all pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
+      "description": "a POST request with one medium",
+      "provider_state": "a contact with id 'abc' exists",
       "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials"
-      },
-      "response": {
-        "status": 200,
+        "method": "post",
+        "path": "/contacts/abc/media",
         "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
+          "Content-Type": "application/vnd.api+json"
         },
         "body": {
-          "pagerduty_credentials": [
+          "media": [
             {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
+              "type": "sms",
+              "address": "0123456789",
+              "interval": 300,
+              "rollup_threshold": 5
             }
           ]
         }
-      }
-    },
-    {
-      "description": "a GET request for one set of pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc"
       },
       "response": {
-        "status": 200,
+        "status": 201,
         "headers": {
           "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for two sets of pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc,872"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "pagerduty_credentials": [
-            {
-              "service_key": "abc",
-              "subdomain": "def",
-              "username": "ghi",
-              "password": "jkl"
-            },
-            {
-              "service_key": "mno",
-              "subdomain": "pqr",
-              "username": "stu",
-              "password": "vwx"
-            }
-          ]
-        }
-      }
-    },
-    {
-      "description": "a GET request for one set of pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "get",
-        "path": "/pagerduty_credentials/abc"
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
         },
         "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
+          "abc_sms"
         ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc,872",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
-        ]
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a PATCH request for pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "patch",
-        "path": "/pagerduty_credentials/abc",
-        "headers": {
-          "Content-Type": "application/json-patch+json"
-        },
-        "body": [
-          {
-            "op": "replace",
-            "path": "/pagerduty_credentials/0/password",
-            "value": "pswrd"
-          }
-        ]
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
-      }
-    },
-    {
-      "description": "a DELETE request for one set of pagerduty credentials",
-      "provider_state": "a contact with id 'abc' has pagerduty credentials",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for two sets of pagerduty credentials",
-      "provider_state": "contacts with ids 'abc' and '872' have pagerduty credentials",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc,872",
-        "body": null
-      },
-      "response": {
-        "status": 204,
-        "body": ""
-      }
-    },
-    {
-      "description": "a DELETE request for one set of pagerduty credentials",
-      "provider_state": "no contact exists",
-      "request": {
-        "method": "delete",
-        "path": "/pagerduty_credentials/abc",
-        "body": null
-      },
-      "response": {
-        "status": 404,
-        "headers": {
-          "Content-Type": "application/vnd.api+json; charset=utf-8"
-        },
-        "body": {
-          "errors": [
-            "could not find contact 'abc'"
-          ]
-        }
       }
     }
   ],

--- a/spec/resources/pagerduty_credentials_spec.rb
+++ b/spec/resources/pagerduty_credentials_spec.rb
@@ -13,8 +13,7 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
     it "submits a POST request for pagerduty credentials" do
       data = [{:service_key => 'abc',
                :subdomain   => 'def',
-               :username    => 'ghi',
-               :password    => 'jkl',
+               :token       => 'ghi',
               }]
 
       flapjack.given("a contact with id 'abc' exists").
@@ -34,8 +33,7 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
     it "can't find the contact to create pagerduty credentials for" do
       data = [{:service_key => 'abc',
                :subdomain   => 'def',
-               :username    => 'ghi',
-               :password    => 'jkl',
+               :token       => 'ghi',
               }]
 
       flapjack.given("no contact exists").
@@ -61,8 +59,7 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
       pdc_data = [{
         :service_key => 'abc',
         :subdomain   => 'def',
-        :username    => 'ghi',
-        :password    => 'jkl',
+        :token       => 'ghi',
       }]
 
       flapjack.given("a contact with id 'abc' has pagerduty credentials").
@@ -81,8 +78,7 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
       pdc_data = [{
         :service_key => 'abc',
         :subdomain   => 'def',
-        :username    => 'ghi',
-        :password    => 'jkl',
+        :token       => 'ghi',
       }]
 
       flapjack.given("a contact with id 'abc' has pagerduty credentials").
@@ -101,13 +97,11 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
       pdc_data = [{
         :service_key => 'abc',
         :subdomain   => 'def',
-        :username    => 'ghi',
-        :password    => 'jkl',
+        :token       => 'ghi',
       }, {
         :service_key => 'mno',
         :subdomain   => 'pqr',
-        :username    => 'stu',
-        :password    => 'vwx',
+        :token       => 'stu',
       }]
 
       flapjack.given("contacts with ids 'abc' and '872' have pagerduty credentials").
@@ -147,12 +141,12 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
         with(:method => :patch,
              :path => '/pagerduty_credentials/abc',
              :headers => {'Content-Type'=>'application/json-patch+json'},
-             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/password', :value => 'pswrd'}]).
+             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/token', :value => 'token123'}]).
         will_respond_with(
           :status => 204,
           :body => '' )
 
-      result = Flapjack::Diner.update_pagerduty_credentials('abc', :password => 'pswrd')
+      result = Flapjack::Diner.update_pagerduty_credentials('abc', :token => 'token123')
       expect(result).not_to be_nil
       expect(result).to be_truthy
     end
@@ -163,12 +157,12 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
         with(:method => :patch,
              :path => '/pagerduty_credentials/abc,872',
              :headers => {'Content-Type'=>'application/json-patch+json'},
-             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/password', :value => 'pswrd'}]).
+             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/token', :value => 'token123'}]).
         will_respond_with(
           :status => 204,
           :body => '' )
 
-      result = Flapjack::Diner.update_pagerduty_credentials('abc', '872', :password => 'pswrd')
+      result = Flapjack::Diner.update_pagerduty_credentials('abc', '872', :token => 'token123')
       expect(result).not_to be_nil
       expect(result).to be_truthy
     end
@@ -179,12 +173,12 @@ describe Flapjack::Diner::Resources::PagerdutyCredentials, :pact => true do
         with(:method => :patch,
              :path => '/pagerduty_credentials/abc',
              :headers => {'Content-Type'=>'application/json-patch+json'},
-             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/password', :value => 'pswrd'}]).
+             :body => [{:op => 'replace', :path => '/pagerduty_credentials/0/token', :value => 'token123'}]).
         will_respond_with(:status => 404,
                           :headers => {'Content-Type' => 'application/vnd.api+json; charset=utf-8'},
                           :body => {:errors => ["could not find contact 'abc'"]} )
 
-      result = Flapjack::Diner.update_pagerduty_credentials('abc', :password => 'pswrd')
+      result = Flapjack::Diner.update_pagerduty_credentials('abc', :token => 'token123')
       expect(result).to be_nil
       expect(Flapjack::Diner.last_error).to eq(:status_code => 404,
         :errors => ["could not find contact 'abc'"])


### PR DESCRIPTION
on June 16, 2014, PagerDuty [announced](https://developer.pagerduty.com/release_notes) that _Basic Authentication_ was being deprecated.

these changes remove using `username` and `password` for communicating with [PagerDuty REST API](https://developer.pagerduty.com/) in favor of `token`. more details about how PagerDuty API authentication works can be found [here](https://developer.pagerduty.com/documentation/rest/authentication).
- remove occurrences of `username` and `password` in favor of `token`.
- update specs to pass using `token`.

here is the related pull request for `flapjack` itself: https://github.com/flapjack/flapjack/pull/831.

_note: `flapjack-diner-flapjack.json` was also modified after i ran the tests; i am guessing it's an auto-generated file._
